### PR TITLE
[New Feature] Generate Generic Type

### DIFF
--- a/examples/IntegrateAndFire_S1967/main.cpp
+++ b/examples/IntegrateAndFire_S1967/main.cpp
@@ -33,13 +33,11 @@ using namespace boost;
 using namespace insilico;
 using namespace std;
 
-void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
-  N_LIF_S1967::ode_set(variables, dxdt, time, 0);
-}
-
 int main(int argc, char **argv) {
   configuration::initialize(argc, argv);
   configuration::observe("v");
+
+  engine::generate_neurons<N_LIF_S1967>();
 
   state_type variables = engine::get_variables();
   integrate_const(boost::numeric::odeint::runge_kutta4<state_type>(),

--- a/examples/Network_HodgkinHuxleyNeurons/main.cpp
+++ b/examples/Network_HodgkinHuxleyNeurons/main.cpp
@@ -2,8 +2,8 @@
   main.cpp - insilico's example using neuron and synapse for illustrations
 
   Copyright (C) 2014 Collins Assisi, Collins Assisi Lab, IISER, Pune
-  Copyright (C) 2014 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
   Copyright (C) 2014 Arun Neru, Collins Assisi Lab, IISER, Pune <areinsdel@gmail.com>
+  Copyright (C) 2014-2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -35,21 +35,12 @@
 using namespace insilico;
 using namespace std;
 
-void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
-  int neuron_count = engine::neuron_count();
-  int synapse_count = engine::synapse_count();
-
-  for(int neuron_index = 0; neuron_index < neuron_count; ++neuron_index) {
-    N_SquidAxon_HH1952::ode_set(variables, dxdt, time, neuron_index);
-  }
-  for(int synapse_index = 0; synapse_index < synapse_count; ++synapse_index) {
-    S_DefaultSynapse::ode_set(variables, dxdt, time, synapse_index);
-  }
-}
-
 int main(int argc, char **argv) {
   configuration::initialize(argc, argv);
   configuration::observe("v");
+
+  engine::generate_neurons<N_SquidAxon_HH1952>(2);
+  engine::generate_synapse<S_DefaultSynapse>(2);
 
   state_type variables = engine::get_variables();
   integrate_const(boost::numeric::odeint::runge_kutta4<state_type>(),

--- a/examples/SingleNeuron_HH1952/main.cpp
+++ b/examples/SingleNeuron_HH1952/main.cpp
@@ -87,7 +87,7 @@ class I_Leak {
   }
 };
 
-class HH_Neuron {
+class HH_Neuron : Neuron {
  public:
   static void ode_set(state_type &variables, state_type &dxdt, const double t, int index) {
     int v_index = engine::neuron_index(index, "v");
@@ -105,9 +105,9 @@ class HH_Neuron {
   }
 };
 
-void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
-  HH_Neuron::ode_set(variables, dxdt, time, 0);
-}
+// void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
+//   HH_Neuron::ode_set(variables, dxdt, time, 0);
+// }
 
 int main(int argc, char **argv) {
   configuration::initialize(argc, argv);

--- a/examples/SingleNeuron_HH1952/main.cpp
+++ b/examples/SingleNeuron_HH1952/main.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 class I_Na {
  public:
-  static void current(state_type &variables, state_type &dxdt, const double t, int index) {
+  static void current(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     double gna = 120, ena = 115;
 
     int v_index = engine::neuron_index(index, "v");
@@ -57,7 +57,7 @@ class I_Na {
 
 class I_K {
  public:
-  static void current(state_type &variables, state_type &dxdt, const double t, int index) {
+  static void current(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     double gk = 36, ek = -12;
 
     int v_index = engine::neuron_index(index, "v");
@@ -77,7 +77,7 @@ class I_K {
 
 class I_Leak {
  public:
-  static void current(state_type &variables, state_type &dxdt, const double t, int index) {
+  static void current(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     double gl = 0.3, el = 10.6;
 
     int v_index = engine::neuron_index(index, "v");
@@ -87,9 +87,9 @@ class I_Leak {
   }
 };
 
-class HH_Neuron : Neuron {
+class HH_Neuron : public Neuron {
  public:
-  static void ode_set(state_type &variables, state_type &dxdt, const double t, int index) {
+  void ode_set(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     int v_index = engine::neuron_index(index, "v");
     
     I_Na::current(variables, dxdt, t, index);
@@ -105,13 +105,11 @@ class HH_Neuron : Neuron {
   }
 };
 
-// void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
-//   HH_Neuron::ode_set(variables, dxdt, time, 0);
-// }
-
 int main(int argc, char **argv) {
   configuration::initialize(argc, argv);
   configuration::observe("v");
+
+  engine::generate_neurons<HH_Neuron>();
 
   state_type variables = engine::get_variables();
   integrate_const(boost::numeric::odeint::runge_kutta4<state_type>(),

--- a/examples/SingleNeuron_InjectedCurrent/main.cpp
+++ b/examples/SingleNeuron_InjectedCurrent/main.cpp
@@ -87,9 +87,9 @@ class I_Leak {
   }
 };
 
-class HH_Neuron {
+class HH_Neuron : public Neuron {
  public:
-  static void ode_set(state_type &variables, state_type &dxdt, const double t, int index) {
+  void ode_set(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     int v_index = engine::neuron_index(index, "v");
 
     I_Na::current(variables, dxdt, t, index);
@@ -106,13 +106,11 @@ class HH_Neuron {
   }
 };
 
-void engine::driver::operator()(state_type &variables, state_type &dxdt, const double time) {
-  HH_Neuron::ode_set(variables, dxdt, time, 0);
-}
-
 int main(int argc, char **argv) {
   configuration::initialize(argc, argv);
   configuration::observe("v");
+
+  engine::generate_neurons<HH_Neuron>();
 
   state_type variables = engine::get_variables();
   integrate_const(boost::numeric::odeint::runge_kutta4<state_type>(),

--- a/include/core/engine/driver.hpp
+++ b/include/core/engine/driver.hpp
@@ -1,5 +1,5 @@
 /*
-  core/engine.hpp - insilico's Simulation Engine API header and source
+  core/engine/driver.hpp - Solver trigger for integration and non-integration
 
   Copyright (C) 2014-2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
 
@@ -17,13 +17,21 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef INCLUDED_INSILICO_CORE_ENGINE_HPP
-#define INCLUDED_INSILICO_CORE_ENGINE_HPP
+#ifndef INCLUDED_INSILICO_CORE_ENGINE_DRIVER_HPP
+#define INCLUDED_INSILICO_CORE_ENGINE_DRIVER_HPP
 
-#ifdef INSILICO_MPI_ENABLE
-#include "parallel/synchronization.hpp"
-#else
-#include "core/engine/serial.hpp"
-#endif
+#include "core/type.hpp"
+
+#include <iostream>
+#include <vector>
+
+namespace insilico { namespace engine {
+
+class driver {
+ public:
+  void operator()(state_type &variables, state_type &dxdt, const double time);
+};
+
+} } // namespace insilico::engine
 
 #endif

--- a/include/core/engine/generate.hpp
+++ b/include/core/engine/generate.hpp
@@ -21,6 +21,7 @@
 #define INCLUDED_INSILICO_CORE_ENGINE_GENERATE_HPP
 
 #include "core/type.hpp"
+#include "core/engine/driver.hpp"
 
 #include <boost/numeric/odeint.hpp>
 

--- a/include/core/engine/generate.hpp
+++ b/include/core/engine/generate.hpp
@@ -1,5 +1,5 @@
 /*
-  core/engine/serial.hpp - insilico engine serial API header and source
+  core/engine/generate.hpp - Type generation and management
 
   Copyright (C) 2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
 
@@ -47,7 +47,7 @@ auto generate_synapse(unsinged count = 1) -> void {
   synapse_objects_count.push_back(count);
 }
 
-void engine::driver::operator()(state_type &_state, state_type &_dxdt, const double time) {
+auto driver::operator()(state_type &_state, state_type &_dxdt, const double time) -> void {
   for(std::vector<Neuron*>::size_type type = 0; type < neuron_objects.size(); ++type) {
     for(int iter = 0; iter < neuron_objects_count[type]; ++iter) {
       neuron_objects[type] -> ode_set(_state, _dxdt, time, iter);

--- a/include/core/engine/generate.hpp
+++ b/include/core/engine/generate.hpp
@@ -1,0 +1,65 @@
+/*
+  core/engine/serial.hpp - insilico engine serial API header and source
+
+  Copyright (C) 2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef INCLUDED_INSILICO_CORE_ENGINE_GENERATE_HPP
+#define INCLUDED_INSILICO_CORE_ENGINE_GENERATE_HPP
+
+#include "core/type.hpp"
+
+#include <boost/numeric/odeint.hpp>
+
+#include <iostream>
+#include <vector>
+
+namespace insilico { namespace engine {
+
+std::vector< Neuron* > neuron_objects;
+std::vector< int > neuron_objects_count;
+
+std::vector< Synapse* > synapse_objects;
+std::vector< int > synapse_objects_count;
+
+template<class T>
+auto generate_neurons(unsinged count = 1) -> void {
+  neuron_objects.push_back(new T());
+  neuron_objects_count.push_back(count);
+}
+
+template<class T>
+auto generate_synapse(unsinged count = 1) -> void {
+  synapse_objects.push_back(new T());
+  synapse_objects_count.push_back(count);
+}
+
+void engine::driver::operator()(state_type &_state, state_type &_dxdt, const double time) {
+  for(std::vector<Neuron*>::size_type type = 0; type < neuron_objects.size(); ++type) {
+    for(int iter = 0; iter < neuron_objects_count[type]; ++iter) {
+      neuron_objects[type] -> ode_set(_state, _dxdt, time, iter);
+    }
+  }
+  for(std::vector<Synapse*>::size_type type = 0; type < synapse_objects.size(); ++type) {
+    for(int j = 0; j < synapse_objects_count[type]; ++j) {
+      synapse_objects[type] -> ode_set(_state, _dxdt, time, iter);
+    }
+  }
+}
+
+} } // namespace insilico::engine
+
+#endif

--- a/include/core/engine/generate.hpp
+++ b/include/core/engine/generate.hpp
@@ -31,31 +31,31 @@
 namespace insilico { namespace engine {
 
 std::vector< Neuron* > neuron_objects;
-std::vector< int > neuron_objects_count;
+std::vector< unsigned > neuron_objects_count;
 
 std::vector< Synapse* > synapse_objects;
-std::vector< int > synapse_objects_count;
+std::vector< unsigned > synapse_objects_count;
 
 template<class T>
-auto generate_neurons(unsinged count = 1) -> void {
+auto generate_neurons(unsigned count = 1) -> void {
   neuron_objects.push_back(new T());
   neuron_objects_count.push_back(count);
 }
 
 template<class T>
-auto generate_synapse(unsinged count = 1) -> void {
+auto generate_synapse(unsigned count = 1) -> void {
   synapse_objects.push_back(new T());
   synapse_objects_count.push_back(count);
 }
 
 auto driver::operator()(state_type &_state, state_type &_dxdt, const double time) -> void {
   for(std::vector<Neuron*>::size_type type = 0; type < neuron_objects.size(); ++type) {
-    for(int iter = 0; iter < neuron_objects_count[type]; ++iter) {
+    for(unsigned iter = 0; iter < neuron_objects_count[type]; ++iter) {
       neuron_objects[type] -> ode_set(_state, _dxdt, time, iter);
     }
   }
   for(std::vector<Synapse*>::size_type type = 0; type < synapse_objects.size(); ++type) {
-    for(int j = 0; j < synapse_objects_count[type]; ++j) {
+    for(unsigned iter = 0; iter < synapse_objects_count[type]; ++iter) {
       synapse_objects[type] -> ode_set(_state, _dxdt, time, iter);
     }
   }

--- a/include/core/engine/serial.hpp
+++ b/include/core/engine/serial.hpp
@@ -21,6 +21,7 @@
 #define INCLUDED_INSILICO_CORE_ENGINE_SERIAL_HPP
 
 #include "core/type.hpp"
+#include "core/engine/driver.hpp"
 #include "core/engine/data.hpp"
 #include "core/engine/serial/common.hpp"
 #include "core/engine/serial/value.hpp"

--- a/include/core/engine/serial.hpp
+++ b/include/core/engine/serial.hpp
@@ -23,6 +23,7 @@
 #include "core/type.hpp"
 #include "core/engine/driver.hpp"
 #include "core/engine/data.hpp"
+#include "core/engine/generate.hpp"
 #include "core/engine/serial/common.hpp"
 #include "core/engine/serial/value.hpp"
 #include "core/engine/serial/index.hpp"

--- a/include/core/type.hpp
+++ b/include/core/type.hpp
@@ -27,6 +27,20 @@ namespace insilico {
 
 using state_type = std::vector<double>;
 
+class Neuron {
+ public:
+  virtual void ode_set() {
+    std::cerr << "*** THIS IS A BUG ***\n";
+  }
+};
+
+class Synapse {
+ public:
+  virtual void ode_set() {
+    std::cerr << "*** THIS IS A BUG ***\n";
+  }
+};
+
 } // namespace insilico
 
 #endif

--- a/include/core/type.hpp
+++ b/include/core/type.hpp
@@ -1,7 +1,7 @@
 /*
-  core/engine.hpp - insilico's Simulation Engine API header and source
+  core/engine/type.hpp - insilico's Simulation Engine API header and source
 
-  Copyright (C) 2014-2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
+  Copyright (C) 2015 Pranav Kulkarni, Collins Assisi Lab, IISER, Pune <pranavcode@gmail.com>
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef INCLUDED_INSILICO_CORE_GLOBAL_TYPE_HPP
-#define INCLUDED_INSILICO_CORE_GLOBAL_TYPE_HPP
+#ifndef INCLUDED_INSILICO_CORE_TYPE_HPP
+#define INCLUDED_INSILICO_CORE_TYPE_HPP
 
 #include <iostream>
 #include <vector>

--- a/include/core/type.hpp
+++ b/include/core/type.hpp
@@ -29,14 +29,14 @@ using state_type = std::vector<double>;
 
 class Neuron {
  public:
-  virtual void ode_set() {
+  virtual void ode_set(state_type &, state_type &, const double, unsigned) {
     std::cerr << "*** THIS IS A BUG ***\n";
   }
 };
 
 class Synapse {
  public:
-  virtual void ode_set() {
+  virtual void ode_set(state_type &, state_type &, const double, unsigned) {
     std::cerr << "*** THIS IS A BUG ***\n";
   }
 };

--- a/include/neuron/N_LIF_S1967.hpp
+++ b/include/neuron/N_LIF_S1967.hpp
@@ -25,9 +25,9 @@
 
 namespace insilico {
 
-class N_LIF_S1967 {
+class N_LIF_S1967 : public Neuron {
  public:
-  static void ode_set(state_type &variables, state_type &dxdt, const double t, int index) {
+  void ode_set(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     int v_index = engine::neuron_index(index, "v");
 
     double v = variables[v_index];

--- a/include/neuron/N_SquidAxon_HH1952.hpp
+++ b/include/neuron/N_SquidAxon_HH1952.hpp
@@ -29,9 +29,9 @@
 
 namespace insilico {
 
-class N_SquidAxon_HH1952 {
+class N_SquidAxon_HH1952 : public Neuron {
  public:
-  static void ode_set(state_type &variables, state_type &dxdt, const double t, int index) {
+  void ode_set(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     int v_index = engine::neuron_index(index, "v");
     double v = variables[v_index];
 

--- a/include/synapse/S_DefaultSynapse.hpp
+++ b/include/synapse/S_DefaultSynapse.hpp
@@ -24,9 +24,9 @@
 
 namespace insilico {
 
-class S_DefaultSynapse {
+class S_DefaultSynapse : public Synapse {
  public:
-  static void ode_set(const state_type &variables, state_type &dxdt, const double t, int index) {
+  void ode_set(state_type &variables, state_type &dxdt, const double t, unsigned index) {
     int g1_index = engine::synapse_index(index, "g1");
     int g2_index = engine::synapse_index(index, "g2");
 


### PR DESCRIPTION
This feature allows the generation of generic types of higher components Neuron and Synapse. Also controls their execution through Driver internally based on trigger of ode_set of all involved higher level components.
